### PR TITLE
Sprint12 3 a11702 start stop inv

### DIFF
--- a/apache2/recipes/default.rb
+++ b/apache2/recipes/default.rb
@@ -63,6 +63,7 @@ if platform?("redhat", "centos", "scientific", "fedora", "arch", "suse" )
   directory node[:apache][:log_dir] do
     mode 0755
     action :create
+    only_if do !File.directory?("#{node[:apache][:log_dir]}") end
   end
 
   package "perl"


### PR DESCRIPTION
Fix for apache logs creation issue after stop-start operations,
Must be merged together or before my pull request in cookbooks_public (https://github.com/rightscale/cookbooks_public/pull/22)
